### PR TITLE
Fixes #7; restrict issue result set; attach to comment; make it work with CE 8.0.5

### DIFF
--- a/chrome/common/js/comm/gitlab.js
+++ b/chrome/common/js/comm/gitlab.js
@@ -63,7 +63,6 @@ define(['lib/jquery', 'lib/knockout', 'comm/communicator', 'comm/fieldInfo'], fu
               var now = new Date();
               var name = '' + now.toISOString().slice(0, 10) + '-screenshot.png';
               formData.append('file', fileBlob, name);
-              console.log('POST FILE', formData, formData.toString(), fileBlob, binary, binary.length);
               $.ajax({
                 url: fields.project.Option().WebUrl + '/uploads',
                 type: 'POST',

--- a/chrome/common/js/details.js
+++ b/chrome/common/js/details.js
@@ -35,7 +35,7 @@ define(['lib/jquery', 'lib/knockout', 'lib/knockout.validation', 'comm', 'lib/jq
             this.AttachErrors = ko.validation.group([this.Issue, this.Comment]);
             $("#issue").autocomplete({
                 appendTo: "#issue_dialog",
-                minLength: 3,
+                minLength: 2,
                 source: function(request, response) {
                     var search = self.Communicator.search(request.term);
                     if (search != null) {
@@ -119,8 +119,8 @@ define(['lib/jquery', 'lib/knockout', 'lib/knockout.validation', 'comm', 'lib/jq
             var imageData = this.Parent.Editor.getImageData();
             var self = this;
             $("#issue_dialog").showLoading();
-            this.Communicator.comment(this.IssueId(), this.Comment(), this.Fields).then(function () {
-                  return self.Communicator.attach(self.IssueId(), imageData, self.Fields);
+            this.Communicator.attach(self.IssueId(), imageData, self.Fields).then(function() {
+                return self.Communicator.comment(self.IssueId(), self.Comment(), self.Fields);
             }).done(function () {
                 $("#issue_dialog").hideLoading().dialog("close");
                 location.href = self.Communicator.getRedirectUrl(self.IssueId(), self.Fields);

--- a/chrome/common/js/details.js
+++ b/chrome/common/js/details.js
@@ -153,7 +153,7 @@ define(['lib/jquery', 'lib/knockout', 'lib/knockout.validation', 'comm', 'lib/jq
             }
             create.then(function (data) {
                     issueId = data.Id;
-                    return self.Communicator.attach(issueId, imageData, self.Fields);
+                    return self.Communicator.attach(issueId, imageData, self.Fields, true);
                 }).done(function () {
                     $("#issue_dialog").hideLoading().dialog("close");
                     location.href = self.Communicator.getRedirectUrl(issueId, self.Fields);


### PR DESCRIPTION
This PR fixes the "no labels" issue.
Apart from that:
- matches the issue query string against the number + title label, to make the search facility a bit more useful
- reverse attach / comment order to be able to attach the uploaded image directly to the comment body and not to the issue's main description.

Tested against self-hosted GitLab 8.0.5, so the upload target URL has changed!
